### PR TITLE
Make logging level configurable

### DIFF
--- a/taskmap/taskmap_test.py
+++ b/taskmap/taskmap_test.py
@@ -214,6 +214,33 @@ def test_logging_filename_change():
     assert any(name in f for f in os.listdir('./'))
 
 
+def test_default_logging_severity_level():
+    dependencies = {'a': []}
+    funcs = {'a': a}
+    name = 'test-taskmap-default-level'
+    taskmap.create_graph(funcs, dependencies, name=name)
+
+    manager_logger_name = '{}-manager'.format(name)
+    worker_logger_name = '{}-worker'.format(name)
+
+    assert logging.getLogger(manager_logger_name).level == logging.DEBUG
+    assert logging.getLogger(worker_logger_name).level == logging.DEBUG
+
+
+def test_explicit_logging_severity_level():
+    dependencies = {'a': []}
+    funcs = {'a': a}
+    name = 'test-taskmap-explicit-level'
+    taskmap.create_graph(funcs, dependencies, name=name, 
+                         logging_config={'level': logging.ERROR})
+
+    manager_logger_name = '{}-manager'.format(name)
+    worker_logger_name = '{}-worker'.format(name)
+
+    assert logging.getLogger(manager_logger_name).level == logging.ERROR
+    assert logging.getLogger(worker_logger_name).level == logging.ERROR
+
+
 def test_run_pass_args():
     # given
     dependencies = {

--- a/taskmap/taskmap_test.py
+++ b/taskmap/taskmap_test.py
@@ -3,6 +3,7 @@ import logging
 import taskmap
 import pytest
 import time
+import os
 
 # disable logging during tests
 logging.disable(logging.CRITICAL)
@@ -186,6 +187,31 @@ def test_all_names_are_funcs():
 
         # when
         taskmap.create_graph(funcs, dependencies)
+
+
+def test_logging_no_write():
+    # given
+    dependencies = {'a': []}
+    funcs = {'a': a}
+    logging_config = {'write': False}
+
+    # when
+    taskmap.create_graph(funcs, dependencies, name='name', logging_config=logging_config)
+
+
+def test_logging_filename_change():
+    # given
+    dependencies = {'a': []}
+    funcs = {'a': a}
+    name = 'test-taskmap-name'
+    graph = taskmap.create_graph(funcs, dependencies, name=name,
+                                 logging_config={'write': True})
+
+    # when
+    graph = taskmap.run(graph)
+
+    # then
+    assert any(name in name for name in os.listdir('./'))
 
 
 def test_run_pass_args():

--- a/taskmap/taskmap_test.py
+++ b/taskmap/taskmap_test.py
@@ -211,7 +211,7 @@ def test_logging_filename_change():
     graph = taskmap.run(graph)
 
     # then
-    assert any(name in name for name in os.listdir('./'))
+    assert any(name in f for f in os.listdir('./'))
 
 
 def test_run_pass_args():

--- a/taskmap/tgraph.py
+++ b/taskmap/tgraph.py
@@ -192,7 +192,6 @@ def setup_loggers(config):
     ch.setLevel(logging.DEBUG)
     logger.addHandler(ch)
     mlogger.addHandler(ch)
-    mplogging.install_mp_handler(logger)
 
     if config.get('write', True):
         now = dt.datetime.now()
@@ -203,6 +202,7 @@ def setup_loggers(config):
         logger.addHandler(fh)
         mlogger.addHandler(fh)
 
+    mplogging.install_mp_handler(logger)
 
 def create_parallel_compatible_graph(graph, manager):
     return Graph(

--- a/taskmap/tgraph.py
+++ b/taskmap/tgraph.py
@@ -173,23 +173,24 @@ def all_done(graph):
 
 def setup_loggers(config):
     name = config.get('name', 'taskmap')
+    level = config.get('level', logging.DEBUG)
 
     if logging.getLogger('{}-manager'.format(name)).handlers:
         # we've already configured these loggers
         return
 
     mlogger = logging.getLogger('{}-manager'.format(name))
-    mlogger.setLevel(logging.DEBUG)
+    mlogger.setLevel(level)
 
     logger = logging.getLogger('{}-worker'.format(name))
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(level)
 
     formatter = logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
     ch = logging.StreamHandler()
     ch.setFormatter(formatter)
-    ch.setLevel(logging.DEBUG)
+    ch.setLevel(level)
     logger.addHandler(ch)
     mlogger.addHandler(ch)
 
@@ -197,7 +198,7 @@ def setup_loggers(config):
         now = dt.datetime.now()
         logname_frmt = '{}{}.log'.format(name, now.strftime('%m-%d-%Y:%H.%M.%S'))
         fh = logging.FileHandler(logname_frmt)
-        fh.setLevel(logging.DEBUG)
+        fh.setLevel(level)
         fh.setFormatter(formatter)
         logger.addHandler(fh)
         mlogger.addHandler(fh)

--- a/taskmap/tgraph.py
+++ b/taskmap/tgraph.py
@@ -1,3 +1,7 @@
+import logging
+import datetime as dt
+import multiprocessing_logging as mplogging
+
 from itertools import chain
 from operator import contains
 from functools import partial
@@ -5,7 +9,7 @@ from collections import namedtuple
 
 Graph = namedtuple('graph', [
     'funcs', 'dependencies', 'done', 'results', 'in_progress', 'lock',
-    'io_bound'
+    'io_bound', 'name'
 ])
 
 
@@ -35,7 +39,17 @@ def reset_tasks(graph, tasks):
     return graph
 
 
-def create_graph(funcs, dependencies, io_bound=None, done=None, results=None):
+def create_graph(funcs, dependencies, io_bound=None, done=None, results=None,
+                 name='taskmap', logging_config=None):
+    """
+    logging_config is expected to be a dictionary. the keys can be 'name',
+    which names the loggers to be used, and 'write', which specificies whether
+    the log is written to disk. Note if two graphs with the same name are
+    created, only the logging config from the first will be used.
+    """
+    defaults = {'name': name, 'write': False}
+    setup_loggers({**defaults, **(logging_config or {})})
+
     dependencies = {task: list(deps) for task, deps in dependencies.items()}
     io_bound = io_bound or []
     done = done or []
@@ -52,7 +66,9 @@ def create_graph(funcs, dependencies, io_bound=None, done=None, results=None):
         done=list(done),
         results=results,
         lock=0,
-        io_bound=io_bound)
+        io_bound=io_bound,
+        name=name
+    )
 
 
 def check_cyclic_dependency(dependencies):
@@ -155,6 +171,39 @@ def all_done(graph):
     return set(graph.done) == set(graph.dependencies.keys())
 
 
+def setup_loggers(config):
+    name = config.get('name', 'taskmap')
+
+    if logging.getLogger('{}-manager'.format(name)).handlers:
+        # we've already configured these loggers
+        return
+
+    mlogger = logging.getLogger('{}-manager'.format(name))
+    mlogger.setLevel(logging.DEBUG)
+
+    logger = logging.getLogger('{}-worker'.format(name))
+    logger.setLevel(logging.DEBUG)
+
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    ch = logging.StreamHandler()
+    ch.setFormatter(formatter)
+    ch.setLevel(logging.DEBUG)
+    logger.addHandler(ch)
+    mlogger.addHandler(ch)
+    mplogging.install_mp_handler(logger)
+
+    if config.get('write', True):
+        now = dt.datetime.now()
+        logname_frmt = '{}{}.log'.format(name, now.strftime('%m-%d-%Y:%H.%M.%S'))
+        fh = logging.FileHandler(logname_frmt)
+        fh.setLevel(logging.DEBUG)
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+        mlogger.addHandler(fh)
+
+
 def create_parallel_compatible_graph(graph, manager):
     return Graph(
         funcs=manager.dict(graph.funcs),
@@ -163,7 +212,8 @@ def create_parallel_compatible_graph(graph, manager):
         results=manager.dict(graph.results),
         in_progress=manager.list(),
         lock=manager.Value(int, 0),
-        io_bound=manager.list(graph.io_bound))
+        io_bound=manager.list(graph.io_bound),
+        name=graph.name)
 
 
 def recover_values_from_manager(graph):
@@ -174,4 +224,5 @@ def recover_values_from_manager(graph):
         funcs=dict(graph.funcs),
         results=dict(graph.results),
         io_bound=list(graph.io_bound),
-        dependencies=dict(graph.dependencies))
+        dependencies=dict(graph.dependencies),
+        name=graph.name)


### PR DESCRIPTION
Instead of hardcoding logging to be at the DEBUG level, make that
a configuration option to logging_config in the create_graph
function call. If one sets the 'level' key the manager and the
worker logger will have that logging level set.

Tested using added unit tests.