### PR TITLE
Fixed problem mixing normal with async tasks

### DIFF
--- a/taskmap/taskmap.py
+++ b/taskmap/taskmap.py
@@ -38,7 +38,7 @@ async def run_task_async(graph, task, raise_errors=False):
     log(graph).info('pid {}: starting task {}'.format(os.getpid(), task))
 
     try:
-        result = await graph.funcs[task](*args)
+        result = await asyncio.coroutine(graph.funcs[task])(*args)
         return task_success(graph, task, result)
 
     except Exception as error:


### PR DESCRIPTION
There were problems with mixing async and non async tasks. Particularly if __call__ can get forwarded to either a sync or async task
This fixes it by turning an non-async function into a coroutine, if needed